### PR TITLE
Multithreading speed up individual page parsing and OS agnostic paths

### DIFF
--- a/src/catalog.py
+++ b/src/catalog.py
@@ -1,7 +1,7 @@
 import urllib.request
 import bs4 as bs
 
-def get_html_soup(url:str) -> bs.BeautifulSoup:
+def get_html_soup(url: str) -> bs.BeautifulSoup:
     try:
         response = urllib.request.urlopen(url)
     except urllib.error.HTTPError:
@@ -26,9 +26,9 @@ def get_page_course_urls(url) -> list:
         output.append(HEADER + h4.find('a')['href'])
     return output
 
-def get_all_urls() -> None:
+def get_all_urls(output_path: str) -> None:
     URL = "https://www.mcgill.ca/study/2022-2023/courses/search?page="
-    with open("../output/course_urls.txt","w") as fobj:
+    with open(output_path,"w") as fobj:
         for i in range(520):
             url = URL + str(i)
             page_urls = get_page_course_urls(url)
@@ -37,4 +37,3 @@ def get_all_urls() -> None:
 
 if __name__ == "__main__":
     get_all_urls()
-    pass

--- a/src/main.py
+++ b/src/main.py
@@ -3,15 +3,19 @@ from catalog import get_all_urls
 import json
 from os import path
 import sys
+import threading
 
 def scrape() -> None:
-    with open('../output/courses.json', 'w') as outfile:
-            json.dump({"courses":{}}, outfile)
+    output_path = path.join(path.dirname(__file__), '..', 'output')
+    courses_path = path.join(output_path, 'courses.json')
+    with open(courses_path, 'w+') as outfile:
+        json.dump({"courses":{}}, outfile)
 
-    if not path.exists("../output/course_urls.txt"):
-        get_all_urls()
+    urls_path = path.join(output_path, 'course_urls.txt')
+    if not path.exists(urls_path):
+        get_all_urls(urls_path)
 
-    with open("../output/course_urls.txt",'r') as fobj:
+    with open(urls_path,'r') as fobj:
         urls = fobj.read().strip().split("\n")
 
     for url in urls:
@@ -28,9 +32,8 @@ def scrape() -> None:
             continue
         course_code = data["course_code"]
 
-        with open('../output/courses.json', 'r') as outfile:
+        with open(courses_path, 'w+') as outfile:
             json_dict = json.load(outfile)
-        with open('../output/courses.json', 'w') as outfile:
             json_dict["courses"][course_code] = data
             json.dump(json_dict, outfile)
 

--- a/src/page_scraper.py
+++ b/src/page_scraper.py
@@ -121,6 +121,7 @@ def get_other_notes(notes:list) ->list:
     return output
 
 def get_page_json(url:str) -> dict:
+    print(f"Currently parsing {url}")
     course = get_html_soup(url)
     course_code = url.split('/')[-1].strip()
     course_code = "".join(course_code.split('-'))
@@ -156,4 +157,3 @@ def get_page_json(url:str) -> dict:
 if __name__ == "__main__":
     url = "https://www.mcgill.ca/study/2022-2023/courses/math-323"
     print(get_page_json(url))
-    pass


### PR DESCRIPTION
Code runs extremely fast with 50 threads. I also changed the file paths to be OS agnostic using `os.path.join` to allow running on Windows.
```
Currently parsing https://www.mcgill.ca/study/2022-2023/courses/soci-604
Currently parsing https://www.mcgill.ca/study/2022-2023/courses/soci-620
Currently parsing https://www.mcgill.ca/study/2022-2023/courses/soci-621
Currently parsing https://www.mcgill.ca/study/2022-2023/courses/soci-622
Scraped 10390 urls in 49.22809600830078s
writing to disk...
```